### PR TITLE
Adding addTagValueProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,6 @@ class RenanBr\BibTexParser\Listener implements RenanBr\BibTexParser\ListenerInte
     public function setTagNameCase(int|null $case): void;
 
     /**
-     * @param callable|null $processor Function to be applied to every member of an BibTeX entry.
-     *                                 It uses array_walk() internally.
-     *                                 The suggested signature for the argument is:
-     *                                 function (string &$value, string $tag);
-     * @deprecated
-     */
-    public function addTagValueProcessor(callable|null $processor): void;
-
-    /**
      * @param  $processor Function or array of functions to be applied to every member
      *                    of an BibTeX entry. Uses array_walk() internally.
      *                    The suggested signature for each function argument is:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Its features are:
 - It [concatenates](http://www.bibtex.org/Format/) tag values;
 - It handles [abbreviations](http://www.bibtex.org/Format/);
 - If the first tag has no value, the tag name is interpreted as value of `citation-key` tag instead.
-- It allows to inject tag value processor through `setTagValueProcessor()`.
+- It allows to inject tag value processor through `addTagValueProcessor()`.
   Once BibTeX contain LaTeX, this method may be useful to translate them into HTML, for example.
 - It handles tag name case through `setTagNameCase()`
 
@@ -135,8 +135,20 @@ class RenanBr\BibTexParser\Listener implements RenanBr\BibTexParser\ListenerInte
      *                                 It uses array_walk() internally.
      *                                 The suggested signature for the argument is:
      *                                 function (string &$value, string $tag);
+     * @deprecated
      */
-    public function setTagValueProcessor(callable|null $processor): void;
+    public function addTagValueProcessor(callable|null $processor): void;
+
+    /**
+     * @param  $processor Function or array of functions to be applied to every member
+     *                    of an BibTeX entry. Uses array_walk() internally.
+     *                    The suggested signature for each function argument is:
+     *                        function (string &$value, string $tag);
+     *                    Note that functions will be applied in the same order
+     *                    in which they were added.
+     * @throws \InvalidArgumentException
+     */
+    public function addTagValueProcessor($processor): void;
 
     /* Inherited and implemented methods */
 
@@ -151,7 +163,7 @@ If you would like to parse the author names included in your entries, you can us
 class. Before exporting the contents, add this processor:
 
 ```php
-$listener->setTagValueProcessor(new RenanBr\BibTexParser\Processor\AuthorProcessor());
+$listener->addTagValueProcessor(new RenanBr\BibTexParser\Processor\AuthorProcessor());
 $entries = $listener->export();
 ```
 

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -65,10 +65,12 @@ class Listener implements ListenerInterface
      *                                 The suggested signature for the argument is:
      *                                 function (string &$value, string $tag);
      *
-     * @deprecated
+     * @deprecated The method setTagValueProcessor is deprecated since 0.5.0 and will
+     *             be removed in version 1.0.0. Use addTagValueProcessor instead.
      */
     public function setTagValueProcessor(callable $processor = null)
     {
+        @trigger_error('Use do_something_else() instead', E_USER_DEPRECATED);
         if (is_null($processor)) {
             $this->tagValueProcessors = [];
 
@@ -88,6 +90,14 @@ class Listener implements ListenerInterface
      */
     public function addTagValueProcessor($processor)
     {
+        // if $processor is a callable array, it will be processed here
+    // (see http://php.net/manual/en/language.types.callable.php#example-75)
+        if (is_callable($processor)) {
+            $this->tagValueProcessors[] = $processor;
+
+            return;
+        }
+    // if control reaches here: it might be a non-callable array
         if (is_array($processor)) {
             // check if each value is callable
         foreach ($processor as $testing) {
@@ -96,11 +106,6 @@ class Listener implements ListenerInterface
             }
         }
             $this->tagValueProcessors = array_merge($this->tagValueProcessors, $processor);
-
-            return;
-        }
-        if (is_callable($processor)) {
-            $this->tagValueProcessors[] = $processor;
 
             return;
         }

--- a/tests/DummyProcessor.php
+++ b/tests/DummyProcessor.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the BibTex Parser.
+ *
+ * (c) Renan de Lima Barbosa <renandelima@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace RenanBr\BibTexParser\Test;
+
+class DummyProcessor
+{
+    public static function myCallbackMethod(&$text, $tag)
+    {
+        $text = "dummy-callback-$text";
+    }
+}

--- a/tests/Listener/TagValueProcessorTest.php
+++ b/tests/Listener/TagValueProcessorTest.php
@@ -132,4 +132,20 @@ class TagValueProcessorTest extends TestCase
         $this->assertSame('basic', $entry['type']);
         $this->assertSame('bar', $entry['foo']);
     }
+
+    public function testAddTagValueProcessorWithCallableArray()
+    {
+        $listener = new Listener();
+        $my_callable_array = ['RenanBr\BibTexParser\Test\DummyProcessor', 'myCallbackMethod'];
+        $listener->addTagValueProcessor($my_callable_array);
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseFile(__DIR__ . '/../resources/valid/basic.bib');
+
+        $entries = $listener->export();
+        $entry = $entries[0];
+        $this->assertSame('dummy-callback-basic', $entry['type']);
+        $this->assertSame('dummy-callback-bar', $entry['foo']);
+    }
 }

--- a/tests/Listener/TagValueProcessorTest.php
+++ b/tests/Listener/TagValueProcessorTest.php
@@ -17,8 +17,9 @@ use RenanBr\BibTexParser\Parser;
 
 class TagValueProcessorTest extends TestCase
 {
-    public function testTagValueProcessor()
+    public function testSetTagValueProcessor()
     {
+        // tests for the deprecated setTagValueProcessor
         $listener = new Listener();
         $listener->setTagValueProcessor(function (&$text, $tag) {
             $text = "processed-$tag-$text";
@@ -32,5 +33,103 @@ class TagValueProcessorTest extends TestCase
         $entry = $entries[0];
         $this->assertSame('processed-type-basic', $entry['type']);
         $this->assertSame('processed-foo-bar', $entry['foo']);
+    }
+
+    public function testAddTagValueProcessor()
+    {
+        $listener = new Listener();
+        $listener->addTagValueProcessor(function (&$text, $tag) {
+            $text = "processed-$tag-$text";
+        });
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseFile(__DIR__ . '/../resources/valid/basic.bib');
+
+        $entries = $listener->export();
+        $entry = $entries[0];
+        $this->assertSame('processed-type-basic', $entry['type']);
+        $this->assertSame('processed-foo-bar', $entry['foo']);
+    }
+
+    public function testAddTagValueProcessorOrder()
+    {
+        $listener = new Listener();
+        $addA = function (&$text, $tag) {
+            $text .= "A";
+        };
+        $addB = function (&$text, $tag) {
+            $text .= "B";
+        };
+
+        $listener->addTagValueProcessor($addA);
+        $listener->addTagValueProcessor($addB);
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseFile(__DIR__ . '/../resources/valid/basic.bib');
+
+        $entries = $listener->export();
+        $entry = $entries[0];
+        $this->assertSame('basicAB', $entry['type']);
+        $this->assertSame('barAB', $entry['foo']);
+    }
+
+    public function testAddTagValueProcessorArrays()
+    {
+        $listener = new Listener();
+        $addA = function (&$text, $tag) {
+            $text .= "A";
+        };
+        $addB = function (&$text, $tag) {
+            $text .= "B";
+        };
+        $addC = function (&$text, $tag) {
+            $text .= "C";
+        };
+
+        $listener->addTagValueProcessor([$addA, $addB]);
+        $listener->addTagValueProcessor([$addC]);
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseFile(__DIR__ . '/../resources/valid/basic.bib');
+
+        $entries = $listener->export();
+        $entry = $entries[0];
+        $this->assertSame('basicABC', $entry['type']);
+        $this->assertSame('barABC', $entry['foo']);
+    }
+
+    public function testInvalidAddTagValueProcessor()
+    {
+        $listener = new Listener();
+        $this->expectException(\InvalidArgumentException::class);
+        $listener->addTagValueProcessor("foo");
+    }
+
+    public function testInvalidAddTagValueProcessorInArray()
+    {
+        $listener = new Listener();
+        $this->expectException(\InvalidArgumentException::class);
+        $listener->addTagValueProcessor(["foo", "bar"]);
+    }
+
+    public function testAddTagValueProcessorThenSetTagValueProcessor()
+    {
+        $listener = new Listener();
+        $listener->addTagValueProcessor(function (&$text, $tag) {
+            $text = "processed-$tag-$text";
+        });
+        $listener->setTagValueProcessor(null);
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseFile(__DIR__ . '/../resources/valid/basic.bib');
+
+        $entries = $listener->export();
+        $entry = $entries[0];
+        $this->assertSame('basic', $entry['type']);
+        $this->assertSame('bar', $entry['foo']);
     }
 }


### PR DESCRIPTION
New function `addTagValueProcessor`. It accepts either a callable or an array of callables. It throws an `\InvalidArgumentException` if the argument does not conform to these types. I haven't found anything on the PSRs about standard exceptions, please check if using this exception is appropriate.

I've changed the code of `setTagValueProcessor` a bit, because now the "empty" state for the variable `$tagValueProcessors` is an empty array, and not `null`. This should not affect anything outside these functions. 

I've added a `@deprecated` tag to the `setTagValueProcessor` function, is there anything else that should be done?

I've also included tests to check the expected behavior of both functions, even if used in conjunction. 