### PR TITLE
Skip LatexToUnicodeProcessorTest if pandoc is not found

### DIFF
--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -21,6 +21,15 @@ use RenanBr\BibTexParser\Processor\LatexToUnicodeProcessor;
  */
 class LatexToUnicodeProcessorTest extends TestCase
 {
+    protected function setUp()
+    {
+        if (!shell_exec('which pandoc')) {
+            $this->markTestSkipped(
+                'Pandoc is not installed, skiping this test'
+            );
+        }
+    }
+
     public function testTextAsInput()
     {
         $processor = new LatexToUnicodeProcessor();

--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -23,7 +23,8 @@ class LatexToUnicodeProcessorTest extends TestCase
 {
     protected function setUp()
     {
-        if (!shell_exec('which pandoc')) {
+        exec('which pandoc', $output, $retVal);
+        if ($retVal !== 0) {
             $this->markTestSkipped(
                 'Pandoc is not installed, skiping this test'
             );


### PR DESCRIPTION
Hi. This PR resolves #68 by marking the test as incomplete is pandoc command is not found on the system. Other tests pass but this 3 tests get marked as skiped and php prints a warning about it with the text: 'Pandoc is not found, skiping this test'