### PR TITLE
Add 7.4snapshot to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4snapshot
     - nightly
 
 matrix:
     allow_failures:
+        - php: 7.4snapshot
         - php: nightly
 
 before_script:


### PR DESCRIPTION
This will add 7.4snapshot for now to matrix builds.

Also this will ignore possible failures for 7.4 as long
as there is no final release.

Solve #77