### PR TITLE
Do not process "_original" and "_type" tags by default

### DIFF
--- a/src/Processor/TagCoverageTrait.php
+++ b/src/Processor/TagCoverageTrait.php
@@ -16,7 +16,10 @@ trait TagCoverageTrait
     use TagSearchTrait;
 
     /** @var array */
-    private $tagCoverageList = [];
+    private $tagCoverageList = [
+        '_original',
+        '_type',
+    ];
 
     /** @var string */
     private $tagCoverageStrategy = 'blacklist';

--- a/tests/Processor/KeywordsProcessorTest.php
+++ b/tests/Processor/KeywordsProcessorTest.php
@@ -72,7 +72,11 @@ class KeywordsProcessorTest extends TestCase
         $this->assertCount(4, $entries[0]);
         $this->assertSame('keywordsSimple', $entries[0]['type']); // @legacy
         $this->assertSame('keywordsSimple', $entries[0]['_type']);
-        $this->assertTrue(\is_string($entries[0]['_original']));
+
+        $this->assertSame(
+            trim(file_get_contents(__DIR__.'/../resources/valid/keywords-simple.bib')),
+            $entries[0]['_original'])
+        ;
 
         $this->assertSame(['foo', 'bar'], $entries[0]['keywords']);
     }

--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -75,7 +75,11 @@ class LatexToUnicodeProcessorTest extends TestCase
         $this->assertCount(4, $entries[0]);
         $this->assertSame('tagContentLatex', $entries[0]['type']); // @legacy
         $this->assertSame('tagContentLatex', $entries[0]['_type']);
-        $this->assertTrue(\is_string($entries[0]['_original']));
+
+        $this->assertSame(
+            trim(file_get_contents(__DIR__.'/../resources/valid/tag-contents-latex.bib')),
+            $entries[0]['_original'])
+        ;
 
         $this->assertSame('cafés', $entries[0]['consensus']);
     }

--- a/tests/Processor/NamesProcessor/IntegrationTest.php
+++ b/tests/Processor/NamesProcessor/IntegrationTest.php
@@ -35,7 +35,11 @@ class IntegrationTest extends TestCase
         $this->assertCount(4, $entries[0]);
         $this->assertSame('authorssimple', $entries[0]['type']); // @legacy
         $this->assertSame('authorssimple', $entries[0]['_type']);
-        $this->assertTrue(\is_string($entries[0]['_original']));
+
+        $this->assertSame(
+            trim(file_get_contents(__DIR__.'/../../resources/valid/authors-simple.bib')),
+            $entries[0]['_original'])
+        ;
 
         $this->assertCount(1, $entries[0]['author']);
         $this->assertSame('John', $entries[0]['author'][0]['first']);


### PR DESCRIPTION
fix #88 