### PR TITLE
Allow special characters in citation keys

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -266,7 +266,7 @@ class Parser
      */
     private function readTagName($char)
     {
-        if (preg_match('/^[a-zA-Z0-9_\+:\-\.\/]$/', $char)) {
+        if (preg_match('/^[a-zA-Z0-9_\+:\-\.\/\x{00C0}-\x{01FF}]$/u', $char)) {
             $this->appendToBuffer($char);
         } elseif ($this->isWhitespace($char) && empty($this->buffer)) {
             // Skips because we didn't start reading

--- a/tests/Parser/CitationKeyTest.php
+++ b/tests/Parser/CitationKeyTest.php
@@ -67,4 +67,28 @@ class CitationKeyTest extends TestCase
         $this->assertSame('Kyriakakis:2016:EMI:3003733.3003777', $text);
         $this->assertSame(Parser::CITATION_KEY, $type);
     }
+
+    /**
+     * @group regression
+     * @group bug94
+     *
+     * @see https://github.com/renanbr/bibtex-parser/issues/94
+     */
+    public function testSpecialCharactersKey()
+    {
+        $listener = new DummyListener();
+
+        $parser = new Parser();
+        $parser->addListener($listener);
+        $parser->parseString('@article{schünemann2013evaluation}');
+
+        // 0 -> type
+        // 1 -> citation key
+        // 2 -> original entry
+        $this->assertCount(3, $listener->calls);
+        list($text, $type) = $listener->calls[1];
+
+        $this->assertSame('schünemann2013evaluation', $text);
+        $this->assertSame(Parser::CITATION_KEY, $type);
+    }
 }


### PR DESCRIPTION
See #94, this PR allows special characters in a [Unicode range](https://unicode-table.com/en/#latin-1-supplement) from `0x00c0` to  `0x01FF`. I did not really know where to make the cut, this might be modified to another value as I am no expert in special characters of foreign languages.