### PR TITLE
Bugfix of issue #102: do not auto wrap long lines

### DIFF
--- a/src/Processor/LatexToUnicodeProcessor.php
+++ b/src/Processor/LatexToUnicodeProcessor.php
@@ -66,6 +66,7 @@ class LatexToUnicodeProcessor
             return $this->pandoc->runWith($text, [
                 'from' => 'latex',
                 'to' => 'plain',
+                'wrap' => 'none',
             ]);
         } catch (PandocException $exception) {
             throw new ProcessorException(sprintf('Error while processing LaTeX to Unicode: %s', $exception->getMessage()), 0, $exception);

--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -86,7 +86,7 @@ class LatexToUnicodeProcessorTest extends TestCase
     
     public function testDoNotWrapLongText()
     {
-        $longText = '01234567890123456789012345678901234567890123456789012345678901234567890123456789'
+        $longText = '01234567890123456789012345678901234567890123456789012345678901234567890123456789';
         $processor = new LatexToUnicodeProcessor();
         $entry = $processor([
             'text' => $longText,

--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -83,4 +83,15 @@ class LatexToUnicodeProcessorTest extends TestCase
 
         $this->assertSame('cafés', $entries[0]['consensus']);
     }
+    
+    public function testDoNotWrapLongText()
+    {
+        $longText = '01234567890123456789012345678901234567890123456789012345678901234567890123456789'
+        $processor = new LatexToUnicodeProcessor();
+        $entry = $processor([
+            'text' => $longText,
+        ]);
+
+        $this->assertSame($longText, $entry['text']);
+    }
 }


### PR DESCRIPTION
This change disables auto-wrapping of field content that is longer than 72 characters with newline characters.

Please note that some php-cs-fixer related problems are still **open** (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/UPGRADE-v3.md for details on breaking API changes).