### PR TITLE
Improved test case of issue #102

### DIFF
--- a/tests/Processor/LatexToUnicodeProcessorTest.php
+++ b/tests/Processor/LatexToUnicodeProcessorTest.php
@@ -86,7 +86,7 @@ class LatexToUnicodeProcessorTest extends TestCase
 
     public function testDoNotWrapLongText()
     {
-        $longText = '01234567890123456789012345678901234567890123456789012345678901234567890123456789';
+        $longText = '0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789';
         $processor = new LatexToUnicodeProcessor();
         $entry = $processor([
             'text' => $longText,


### PR DESCRIPTION
Added whitespace characters instead of continuous 80 digit sequence - not sure if Pandoc's auto wrapping feature is aware of whitespace characters