### PR TITLE
If installed, prefer the `ueberdosis/pandoc` package over `ryakad/pandoc-php`

### DIFF
--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -26,6 +26,8 @@ jobs:
                   php-version: 7.4
                   tools: php-cs-fixer:2, cs2pr
 
+            - run: mkdir var
+
             - name: Cache PHP Coding Standards
               uses: actions/cache@v2
               with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,8 @@ jobs:
                 include:
                     - php-version: '8.0'
                       coverage: true
+                    - php-version: '8.2'
+                      with-ueberdosis-pandoc: true
 
         steps:
 
@@ -38,6 +40,12 @@ jobs:
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v2
+
+            - name: Install Pandoc wrapper
+              if: ${{ matrix.with-ueberdosis-pandoc }}
+              run: |
+                composer remove --dev ryakad/pandoc-php
+                composer require --dev ueberdosis/pandoc
 
             - name: Run PHPUnit
               run: vendor/bin/phpunit --testdox ${{ matrix.coverage && '--coverage-clover ./coverage.xml' || '--no-coverage' }}

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ You might want to read them as unicode instead.
 The `LatexToUnicodeProcessor` class solves this problem, but before adding the processor to the listener you must:
 
 - [install Pandoc](http://pandoc.org/installing.html) in your system; and
-- add [ryakad/pandoc-php](https://github.com/ryakad/pandoc-php) as a dependency of your project.
+- add [ryakad/pandoc-php](https://github.com/ryakad/pandoc-php) or [ueberdosis/pandoc](https://github.com/ueberdosis/pandoc) as a dependency of your project.
 
 <details><summary>Usage</summary>
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "ryakad/pandoc-php": "^1.0"
     },
     "suggest": {
-        "ryakad/pandoc-php": "Needed to support LaTeX decoder in class RenanBr\\BibTexParser\\Processor\\LatexToUnicodeProcessor"
+        "ryakad/pandoc-php": "Needed to support LaTeX decoder in class RenanBr\\BibTexParser\\Processor\\LatexToUnicodeProcessor",
+        "ueberdosis/pandoc": "Alternate Pandoc PHP package which (if available) will be preferred over ryakad/pandoc-php"
     },
     "config": {
         "sort-packages": true

--- a/src/Processor/LatexToUnicodeProcessor.php
+++ b/src/Processor/LatexToUnicodeProcessor.php
@@ -61,7 +61,7 @@ class LatexToUnicodeProcessor
     private function decode($text)
     {
         try {
-            return $this->getConverter()($text);
+            return \call_user_func($this->getConverter(), $text);
         } catch (Exception $exception) {
             throw new ProcessorException(sprintf('Error while processing LaTeX to Unicode: %s', $exception->getMessage()), 0, $exception);
         }
@@ -79,17 +79,18 @@ class LatexToUnicodeProcessor
         if (InstalledVersions::isInstalled('ueberdosis/pandoc')) {
             $pandoc = new Pandoc();
 
-            return $this->converter = function ($text) use ($pandoc) {
-                return substr($pandoc->input($text)->execute([
+            return $this->converter = static function ($text) use ($pandoc) {
+                // @phpstan-ignore-next-line
+                return mb_substr($pandoc->input($text)->execute([
                     '--from', 'latex',
                     '--to', 'plain',
                     '--wrap', 'none',
                 ]), 0, -1);
             };
-        } else if (InstalledVersions::isInstalled('ryakad/pandoc-php')) {
+        } elseif (InstalledVersions::isInstalled('ryakad/pandoc-php')) {
             $pandoc = new Pandoc();
 
-            return $this->converter = function ($text) use ($pandoc) {
+            return $this->converter = static function ($text) use ($pandoc) {
                 return $pandoc->runWith($text, [
                     'from' => 'latex',
                     'to' => 'plain',


### PR DESCRIPTION
This pull request presents a possible solution for renanbr/bibtex-parser#107, i.e. it will cause the [ueberdosis/pandoc](https://packagist.org/packages/ueberdosis/pandoc) package to be preferred over [ryakad/pandoc-php](https://packagist.org/packages/ryakad/pandoc-php) if it is installed.